### PR TITLE
fix(cpp_analyzer.py): Remove .c and .h file extensions from supported…

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ Axle supports multiple programming languages through dedicated analyzers:
 ### **Currently Supported:**
 - **Python** (`.py`)
 - **JavaScript** (`.js`, `.jsx`, `.mjs`, `.cjs`)
-- **C/C++** (`.c`, `.cpp`, `.cc`, `.cxx`, `.h`, `.hpp`, `.hxx`) ✨ *New!*
+- **C++** (`.cpp`, `.cc`, `.cxx`, `.hpp`, `.hxx`)
+- **Julia** (`.jl`) ✨ *New!*
 
 ### **Planned Languages:**
 - TypeScript (`.ts`, `.tsx`)
@@ -150,7 +151,7 @@ To add support for a new language:
 3. **Add tests** in `tests/test_<language>_analyzer.py`
 4. **Update documentation**
 
-See `javascript_analyzer.py` and `cpp_analyzer.py` for reference implementations.
+See `javascript_analyzer.py`, `cpp_analyzer.py`, and `julia_analyzer.py` for reference implementations.
 
 ## Interactive Features
 

--- a/src/axle/treesitter/analyzers/cpp_analyzer.py
+++ b/src/axle/treesitter/analyzers/cpp_analyzer.py
@@ -17,7 +17,7 @@ from ..models import (
 
 class CppAnalyzer(BaseAnalyzer):
     LANGUAGE_NAME = "cpp"
-    FILE_EXTENSIONS = (".cpp", ".cc", ".cxx", ".c", ".h", ".hpp", ".hxx")
+    FILE_EXTENSIONS = (".cpp", ".cc", ".cxx", ".hpp", ".hxx")  # Removed .c and .h (pure C files)
 
     def _extract_include_path(self, node: Node, source_code: bytes) -> Optional[str]:
         """Extract include path from #include statement."""


### PR DESCRIPTION
… file types

Updated the file extension list to exclude .c and .h files, as they are pure C files and not relevant to C++ analysis.